### PR TITLE
manifest: Remove hard coded URL

### DIFF
--- a/ir.imansalmani.iplan.json
+++ b/ir.imansalmani.iplan.json
@@ -31,7 +31,7 @@
                 {
                     "type" : "git",
                     "branch": "main",
-                    "url" : "file:///home/iman/Projects/iplan"
+                    "url" : "."
                 }
             ]
         }


### PR DESCRIPTION
Source module currently contains a hard coded URL which prevents build instructions from working without modifications. The is MR replaces URL with a relative '.' path which will use the current base DIR

Pro: Will work for everyone regardless of the username used
Con: Cannot be called from outside the base dir anymore

Fixes #1 