### PR TITLE
Appdata related changes

### DIFF
--- a/data/ir.imansalmani.IPlan.metainfo.xml.in
+++ b/data/ir.imansalmani.IPlan.metainfo.xml.in
@@ -40,6 +40,7 @@
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">ir.imansalmani.IPlan.desktop</launchable>
+  <translation type="gettext">iplan</translation>
   <url type="homepage">https://github.com/iman-salmani/iplan</url>
   <url type="bugtracker">https://github.com/iman-salmani/iplan/issues</url>
   <url type="vcs-browser">https://github.com/iman-salmani/iplan</url>

--- a/data/ir.imansalmani.IPlan.metainfo.xml.in
+++ b/data/ir.imansalmani.IPlan.metainfo.xml.in
@@ -54,9 +54,6 @@
     <control>keyboard</control>
     <control>touch</control>
   </recommends>
-  <categories>
-    <category>Utility</category>
-  </categories>
   <content_rating type="oars-1.1" />
   <releases>
     <release version="1.9.2" date="2023-07-17">

--- a/data/ir.imansalmani.IPlan.metainfo.xml.in
+++ b/data/ir.imansalmani.IPlan.metainfo.xml.in
@@ -44,7 +44,6 @@
   <url type="bugtracker">https://github.com/iman-salmani/iplan/issues</url>
   <developer_name>Iman Salmani</developer_name>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
   <requires>

--- a/data/ir.imansalmani.IPlan.metainfo.xml.in
+++ b/data/ir.imansalmani.IPlan.metainfo.xml.in
@@ -3,7 +3,7 @@
   <id>ir.imansalmani.IPlan</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <name translatable="no">IPlan</name>
+  <name translate="no">IPlan</name>
   <summary>Your plan for improving personal life and workflow</summary>
   <description>
     <p>IPlan goal is to be a user-friendly tool for those who want to organize their ether personal life, jobs, or both.</p>
@@ -61,7 +61,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="1.9.2" date="2023-07-17">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fix</p>
         <ul>
           <li>Meta info issue fixed</li>
@@ -69,7 +69,7 @@
       </description>
     </release>
     <release version="1.9.1" date="2023-07-17">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fixes and performance improvements</p>
         <ul>
           <li>Task timers in different parts of ui are synced together</li>
@@ -85,7 +85,7 @@
       </description>
     </release>
     <release version="1.9.0" date="2023-07-14">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>Search button and Primary menu moved to sidebar</li>
@@ -99,12 +99,12 @@
       </description>
     </release>
     <release version="1.8.1" date="2023-07-07">
-      <description translatable="no">
+      <description translate="no">
         <p>Fix bug: Dont set position for new task in SectionBox::handle_new_button_clicked</p>
       </description>
     </release>
     <release version="1.8.0" date="2023-07-07">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>Move up and down option for tasks rows</li>
@@ -116,7 +116,7 @@
       </description>
     </release>
     <release version="1.7.0" date="2023-06-30">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>Chart of Time spent in last 7 days</li>
@@ -129,7 +129,7 @@
       </description>
     </release>
     <release version="1.6.0" date="2023-06-23">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>New design for drag and drop</li>
@@ -144,7 +144,7 @@
       </description>
     </release>
     <release version="1.5.0" date="2023-06-16">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>The task row shows the description, subtasks, due date, and reminder</li>
@@ -160,7 +160,7 @@
       </description>
     </release>
     <release version="1.4.0" date="2023-06-09">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>Backing up system</li>
@@ -174,12 +174,12 @@
       </description>
     </release>
     <release version="1.3.1" date="2023-06-03">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fix</p>
       </description>
     </release>
     <release version="1.3.0" date="2023-06-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Code refactoring, and UI improvements</p>
         <ul>
           <li>New widgets for selecting Date and Time</li>
@@ -189,7 +189,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2023-05-26">
-      <description translatable="no">
+      <description translate="no">
         <p>Subtasks, Bug fixes, and UI improvements</p>
         <ul>
           <li>Task Window which contains task info, subtasks, and records</li>
@@ -201,7 +201,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2023-05-19">
-      <description translatable="no">
+      <description translate="no">
         <p>Performance improvement and records window</p>
         <ul>
           <li>Lazy loading for project tasks and stat</li>
@@ -210,7 +210,7 @@
       </description>
     </release>
     <release version="1.0" date="2023-05-10">
-      <description translatable="no">
+      <description translate="no">
         <p>First stable release.</p>
         <p>Features:</p>
         <ul>

--- a/data/ir.imansalmani.IPlan.metainfo.xml.in
+++ b/data/ir.imansalmani.IPlan.metainfo.xml.in
@@ -42,6 +42,8 @@
   <launchable type="desktop-id">ir.imansalmani.IPlan.desktop</launchable>
   <url type="homepage">https://github.com/iman-salmani/iplan</url>
   <url type="bugtracker">https://github.com/iman-salmani/iplan/issues</url>
+  <url type="vcs-browser">https://github.com/iman-salmani/iplan</url>
+  <url type="translate">https://github.com/iman-salmani/iplan/tree/main/po</url>
   <developer_name>Iman Salmani</developer_name>
   <custom>
     <value key="Purism::form_factor">mobile</value>


### PR DESCRIPTION
### appdata: `translate=no` properties

It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Fix custom-key-duplicated error

Remove one of Purism::form_factor tag to pass appstreamcli validation.

### appdata: Remove categories

Categories can be parsed from desktop files

> If there’s a type="desktop-id" launchable, they are pulled from the desktop file and merged in the AppStream Catalog data. So defining them separately in the MetaInfo is not necessary.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#categories-and-keywords

### appdata: Add vcs-browser and translate URLs

Add vcs-browser and translate URLs to show source code and translation repositories.

### appdata: Add translation tag

> The `<translation/>` tag is an optional tag which can be added to specify the translation domain used for this software component. It may be used by the AppStream distro metadata generator to determine the translation status of the respective software (e.g. which languages the software is translated into and how complete the translations are).

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-translation